### PR TITLE
fix(deps): bump torch to 2.13.0 for jit.script security advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1] - 2026-09-03
+
+- Raise torch pin to 2.13.0 to resolve torch.jit.script memory corruption advisory (Dependabot alert #2)
+
 ## [1.2.0] - 2026-03-16
 
 - Clear notebook outputs to reduce repo size

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 yfinance==1.5.1
 pandas==3.0.3
-torch==2.12.1
+torch==2.13.0
 scikit-learn==1.9.0
 matplotlib==3.11.0
 numpy==2.4.6


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #2 (low severity): PyTorch memory corruption via `torch.jit.script`
- Raises `torch` pin in `requirements.txt` from 2.12.1 to 2.13.0 (first patched version, vulnerable range <= 2.12.1)
- Adds CHANGELOG entry for v1.2.1

## Testing
Runtime verification was skipped: this repo is a notebook archive (SMP.ipynb) with no test suite, and installing torch is a multi-GB download. The manifest pin bump is the complete fix.